### PR TITLE
adding in node_selector argument

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -507,6 +507,8 @@ resource "kubernetes_deployment" "this" {
           key      = "node-role.kubernetes.io/master"
           operator = "Exists"
         }
+
+        node_selector = var.node_selector
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -54,3 +54,11 @@ variable "image_pull_secrets" {
   description = "List of references to secrets in the same namespace to use for pulling the image"
   default     = []
 }
+
+variable "node_selector" {
+  type        = map
+  description = "Map of key value that will be used to select appropriate nodes"
+  default     = {
+    "kubernetes.io/os" = "linux"
+  }
+}


### PR DESCRIPTION
We are currently deploying both linux and windows nodes to our cluster. We encounter an issue whereby the controller does not know which node to deploy the controller to. We managed to modify the deployment in the cluster to include nodeSelector (kubernetes.io/os = linux) and it deployed successfully and fixed our Terraform deployment issue.

This PR is to add in the node_selector field to the kubernetes_deployment resource as this will assist us in our successful deployment.