### PR TITLE
Add version variable for quicker updating of controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ This module creates and manages the following resources:
 | base\_url | Base URL to be used by the HTTP client | `string` | `""` | no |
 | cluster\_identifier | Cluster identifier | `string` | n/a | yes |
 | create\_controller | Controls whether Ocean Controller should be created (it affects all resources) | `bool` | `true` | no |
+| controller\_version | Controller Docker Version | `string` | _<current_version>_ | no |
 | disable\_auto\_update | Disable the auto-update feature | `bool` | `false` | no |
 | enable\_csr\_approval | Enable the CSR approval feature | `bool` | `false` | no |
 | image\_pull\_secrets | List of references to secrets in the same namespace to use for pulling the image | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -333,7 +333,7 @@ resource "kubernetes_deployment" "this" {
         }
 
         container {
-          image             = "spotinst/kubernetes-cluster-controller:1.0.69"
+          image             = "spotinst/kubernetes-cluster-controller:${var.controller_version}"
           name              = "spotinst-kubernetes-cluster-controller"
           image_pull_policy = "Always"
 

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "cluster_identifier" {
   description = "Cluster identifier"
 }
 
+variable "controller_version" {
+  type        = string
+  description = "Set the Docker version for the Ocean Controller that should be deployed"
+  default     = "1.0.70"
+}
+
 variable "base_url" {
   type        = string
   description = "Base URL to be used by the HTTP client"


### PR DESCRIPTION
Docker image was hardcoded, meaning that there was a delay in pushing updates to the versioning.
This way, module users are able to push new versions without branching or waiting for an update. Kept version on the pinned tag rather than `latest` tag.

Kept the variable block quite high up in the `variables.tf` so noticeable on updates.