### PR TITLE
Add Resources Definition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -349,6 +349,14 @@ resource "kubernetes_deployment" "this" {
           name              = "spotinst-kubernetes-cluster-controller"
           image_pull_policy = var.image_pull_policy
 
+
+          resources {
+            limits   = var.resources_limits
+            requests = var.resources_requests
+
+          }
+
+
           liveness_probe {
             http_get {
               path = "/healthcheck"

--- a/variables.tf
+++ b/variables.tf
@@ -75,10 +75,7 @@ variable "image_pull_secrets" {
 
 variable "resources_limits" {
   description = "Definition of resources limits"
-  type = object({
-    cpu    = string
-    memory = string
-  })
+  type        = map(any)
   default = {
     cpu    = "0.5"
     memory = "512Mi"

--- a/variables.tf
+++ b/variables.tf
@@ -76,14 +76,20 @@ variable "image_pull_secrets" {
 variable "resources_limits" {
   description = "Definition of resources limits"
   type        = map(any)
-  default = {
-    cpu    = "0.5"
-    memory = "512Mi"
-  }
+  #   default = {
+  #  cpu    = "0.5"
+  #  memory = "512Mi"
+  # }
+
+  default = {}
 }
 
 variable "resources_requests" {
   description = "Definition of resources requests"
   type        = map(any)
-  default     = {}
+  #   default = {
+  #  cpu    = "0.5"
+  #  memory = "512Mi"
+  # }
+  default = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -72,3 +72,21 @@ variable "image_pull_secrets" {
   description = "List of references to secrets in the same namespace to use for pulling the image"
   default     = []
 }
+
+variable "resources_limits" {
+  description = "Definition of resources limits"
+  type = object({
+    cpu    = string
+    memory = string
+  })
+  default = {
+    cpu    = "0.5"
+    memory = "512Mi"
+  }
+}
+
+variable "resources_requests" {
+  description = "Definition of resources requests"
+  type        = map(any)
+  default     = {}
+}


### PR DESCRIPTION
## Why?

- Add the possibility to configure resources limits / requests for deployment.

```diff
Terraform will perform the following actions:

  # module.eks_addon.module.ocean-controller.kubernetes_deployment.this[0] will be updated in-place
  ~ resource "kubernetes_deployment" "this" {
        id               = "kube-system/spotinst-kubernetes-cluster-controller"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (13 unchanged attributes hidden)


                  ~ container {
                        name                       = "spotinst-kubernetes-cluster-controller"
                        # (9 unchanged attributes hidden)




                      ~ resources {
                          ~ limits   = {
                              - "cpu"    = "500m" -> null
                              - "memory" = "512Mi" -> null
                            }
                            # (1 unchanged attribute hidden)
                        }
                        # (14 unchanged blocks hidden)
                    }


                  ~ toleration {
                      + effect             = "NoExecute"
                      ~ key                = "node-role.kubernetes.io/master" -> "node.kubernetes.io/not-ready"
                      + toleration_seconds = "150"
                        # (1 unchanged attribute hidden)
                    }
                  + toleration {
                      + effect             = "NoExecute"
                      + key                = "node.kubernetes.io/unreachable"
                      + operator           = "Exists"
                      + toleration_seconds = "150"
                    }
                  + toleration {
                      + key      = "node-role.kubernetes.io/master"
                      + operator = "Exists"
                    }
                    # (2 unchanged blocks hidden)
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.


Warning: Resource targeting is in effect

You are creating a plan with the -target option, which means that the result
of this plan may not represent all of the changes requested by the current
configuration.

The -target option is not for routine use, and is provided only for
exceptional situations such as recovering from errors or mistakes, or when
Terraform specifically suggests to use it as part of an error message.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.eks_addon.module.ocean-controller.kubernetes_deployment.this[0]: Modifying... [id=kube-system/spotinst-kubernetes-cluster-controller]
module.eks_addon.module.ocean-controller.kubernetes_deployment.this[0]: Still modifying... [id=kube-system/spotinst-kubernetes-cluster-controller, 10s elapsed]
module.eks_addon.module.ocean-controller.kubernetes_deployment.this[0]: Still modifying... [id=kube-system/spotinst-kubernetes-cluster-controller, 20s elapsed]
module.eks_addon.module.ocean-controller.kubernetes_deployment.this[0]: Modifications complete after 29s [id=kube-system/spotinst-kubernetes-cluster-controller]
```