### PR TITLE
add outputs and remove acd_identifier check in count

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ module "ocean-controller" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.2.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0 |
 
 ## Modules
 
@@ -73,7 +73,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_acd_identifier"></a> [acd\_identifier](#input\_acd\_identifier) | Specifies a unique identifier used by the Ocean AKS Connector when importing an AKS cluster | `string` | `null` | no |
-| <a name="input_aks_connector_enabled"></a> [aks\_connector\_enabled](#input\_aks\_connector\_enabled) | Controls whether the Ocean AKS Connector should be deployed (requires a valid `acd_identifier`) | `bool` | `true` | no |
+| <a name="input_aks_connector_enabled"></a> [aks\_connector\_enabled](#input\_aks\_connector\_enabled) | Controls whether the Ocean AKS Connector should be deployed (requires a valid `acd_identifier`) | `bool` | `false` | no |
 | <a name="input_aks_connector_image"></a> [aks\_connector\_image](#input\_aks\_connector\_image) | Specifies the Docker image name for the Ocean AKS Connector that should be deployed | `string` | `"spotinst/ocean-aks-connector"` | no |
 | <a name="input_aks_connector_job_name"></a> [aks\_connector\_job\_name](#input\_aks\_connector\_job\_name) | Overrides the default job name for the Ocean AKS Connector | `string` | `null` | no |
 | <a name="input_aks_connector_version"></a> [aks\_connector\_version](#input\_aks\_connector\_version) | Specifies the Docker version for the Ocean AKS Connector that should be deployed | `string` | `"1.0.8"` | no |
@@ -100,7 +100,11 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_acd_identifier"></a> [acd\_identifier](#output\_acd\_identifier) | Unique identifier used by the Ocean AKS Connector when importing an AKS cluster |
+| <a name="output_cluster_identifier"></a> [cluster\_identifier](#output\_cluster\_identifier) | Cluster identifier |
+| <a name="output_spotinst_account"></a> [spotinst\_account](#output\_spotinst\_account) | Spot account ID |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Documentation

--- a/examples/azure-installation/README.md
+++ b/examples/azure-installation/README.md
@@ -23,7 +23,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ocean-controller"></a> [ocean-controller](#module\_ocean-controller) | ../.. | n/a |
+| <a name="module_ocean-controller"></a> [ocean-controller](#module\_ocean-controller) | ../.. |  |
 
 ## Resources
 

--- a/examples/azure-installation/main.tf
+++ b/examples/azure-installation/main.tf
@@ -10,6 +10,7 @@ module "ocean-controller" {
   spotinst_account = var.spotinst_account
 
   # Configuration.
-  cluster_identifier = var.cluster_identifier
-  acd_identifier     = var.acd_identifier
+  cluster_identifier    = var.cluster_identifier
+  acd_identifier        = var.acd_identifier
+  aks_connector_enabled = true
 }

--- a/examples/simple-installation/README.md
+++ b/examples/simple-installation/README.md
@@ -23,7 +23,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ocean-controller"></a> [ocean-controller](#module\_ocean-controller) | ../.. | n/a |
+| <a name="module_ocean-controller"></a> [ocean-controller](#module\_ocean-controller) | ../.. |  |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -570,7 +570,7 @@ resource "kubernetes_deployment" "this" {
 }
 
 resource "kubernetes_job" "this" {
-  count = var.create_controller && var.aks_connector_enabled && var.acd_identifier != null ? 1 : 0
+  count = var.create_controller && var.aks_connector_enabled ? 1 : 0
 
   depends_on = [
     kubernetes_config_map.this,

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,22 @@
+output "acd_identifier" {
+  description = "Unique identifier used by the Ocean AKS Connector when importing an AKS cluster"
+  value       = var.acd_identifier
+
+  depends_on = [
+    kubernetes_job.this
+  ]
+}
+
+output "cluster_identifier" {
+  description = "Cluster identifier"
+  value       = kubernetes_config_map.this[0].data["spotinst.cluster-identifier"]
+
+  depends_on = [
+    kubernetes_deployment.this
+  ]
+}
+
+output "spotinst_account" {
+  description = "Spot account ID"
+  value       = kubernetes_secret.this[0].metadata[0].name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -115,7 +115,7 @@ variable "node_selector" {
 variable "aks_connector_enabled" {
   type        = bool
   description = "Controls whether the Ocean AKS Connector should be deployed (requires a valid `acd_identifier`)"
-  default     = true
+  default     = false
 }
 
 variable "aks_connector_image" {


### PR DESCRIPTION
- adds outputs for `acd_identifier`, `cluster_identifier` and `spotinst_account` to be used in subsequent resources
- removes an `acd_identifier` check for not null in count. It's a good candidate to be utilized with some random generators but due to computed nature that could not be used for the variable present in the count field.