### PR TITLE
Updated AWS EKS secondary CIDR compatibility

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -357,7 +357,7 @@ resource "kubernetes_deployment" "this" {
             }
           }
         }
-
+        host_network = true
         container {
           image             = format("%s:%s", var.controller_image, var.controller_version)
           name              = local.prefix


### PR DESCRIPTION
Addresses a bug fix which ensures the spot controller launches on the node's subnet.
Running the spot instance on the secondary pod subnet(secondary CIDR of VPC) fails although that subnet is attached to the NAT GW/IGW

_This is the default pull request template. You can customize it by adding a `pull_request_template.md` at the root of your repo or inside the `.github` folder._

# Jira Ticket

_Include a link to your Jira Ticket_
_Example: [JIRAISS-1234](https://spotinst.atlassian.net/browse/JIRAISS-1234)_

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_

# Checklist:
- [ ] I have filled relevant self assessment ([NodeJS](https://docs.google.com/forms/d/e/1FAIpQLSfl14u9AOBAmxVJ272tvO7XNuXE-EMvWaGcaRZalu1UAKB7RA/viewform), [Frontend](https://docs.google.com/forms/d/e/1FAIpQLSdiBPNKH81w_EkavihVL8Uwb0j7tP8PwJmLFYm2nCOQxz-1qw/viewform), [Backend](https://docs.google.com/forms/d/e/1FAIpQLSed_PsTJ5-XIWkFL6BSDE2AQRBVPmwc3PAmHZkUn-erzVI37Q/viewform?usp=sf_link))
- [ ] I have run ESlint on my changes and fixed all warnings and errors (**NodeJS & Frontend Services**)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have validated all the requirements in the Jira task were answered
- [ ] I have all neccessary approvals for the design/mini design of this task
- [ ] I have approved the API changes and granular permission patterns (documentation subtask) (**For public services only**) 
