### PR TITLE
Add tolerations to aks-connector job

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -705,6 +705,18 @@ resource "kubernetes_job" "this" {
 
         dns_policy     = "Default"
         restart_policy = "Never"
+
+        dynamic "toleration" {
+          for_each = var.tolerations
+
+          content {
+            key                = lookup(toleration.value, "key", null)
+            value              = lookup(toleration.value, "value", null)
+            effect             = lookup(toleration.value, "effect", null)
+            operator           = lookup(toleration.value, "operator", null)
+            toleration_seconds = lookup(toleration.value, "toleration_seconds", null)
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Pass on the same tolerations that are for the controller to the aks-connector job itself.

Noticed an error in AKS, as default nodepools get created with the Taint "CriticalAddonsOnly=true:NoSchedule"
To resolve that, I have added toleration, but that toleration was applied only to the long-running controller pod, and not the aks-connect Job.